### PR TITLE
Url refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,33 @@ Requires Python >= 3.5
 
         virtualenv -p python3 ENV
         source ENV/bin/activate
-    
+
 3. Copy configuration file.
 
         cp example.config.py config.py
-    
+
 4. Edit configuration file. The file is annotated with descriptions of the configuration options.
 
 ## Running
 To run batch-loader:
 
-    python batch_loader.py <path to csv>
-
+    `python batch_loader.py <path to csv>`
+    OR if instead of haveing the column `files` you have the column `fulltext_url` of the related resource
+    `python batch_loader.py <path to csv> --url`
+    see example.csv and url_example.csv
 
 ## Specification of CSV
-1. The first row must contain the field names.
+1. The first row must contain the field names. (unless --url is given)
 2. Fields that take multiple values should be placed in multiple columns.
    Each field name should be appended with an incrementing integer. For
    example, "author1", "author2", "author3". Even if there is only a
    single entry, but the field is repeating, the field name should end with "1".
-   ()Fields with multiple values will be passed as lists to GWSS.)
-3. The following fields are required: files, object_type, title, author1, 
+   (Fields with multiple values will be passed as lists to GWSS.)
+3. The following fields are required: files (or fulltext_url for this --url variant), object_type, title, author1,
    type_of_work1, rights.
 4. The following fields are optional, but if provided must use these field names:
-   first_file, gwss_id.
-5. Additional fields included in the CSV will be passed to GWSS using the provided 
+   first_file, gwss_id. (TODO)
+5. Additional fields included in the CSV will be passed to GWSS using the provided
    field names. For example, a "subtitle" field included in the CSV will be
    passed as "subtitle" to GWSS.
 6. The ordering of fields is not significant.

--- a/batch_loader.py
+++ b/batch_loader.py
@@ -7,17 +7,59 @@ import json
 import os
 import shutil
 import subprocess
-
+import get_file
 log = logging.getLogger(__name__)
 
 required_field_names = (
     'files',
+    'fulltext_url',
     'resource_type1',
     'title1',
     'creator1',
     'license1'
 )
 
+def run_ingest_process(csv_path,ingest_command,ingest_path,ingest_depositor,url = None,debug = None ):
+    logging.basicConfig(
+        level=logging.DEBUG if debug else logging.INFO
+    )
+    logging.basicConfig(level=logging.DEBUG)
+
+    field_names, rows = load_csv(csv_path)
+    log.info('Loading {} object from {}'.format(len(rows), csv_path))
+    validate_field_names(field_names,url)
+    singular_field_names, repeating_field_names = analyze_field_names(field_names)
+    base_filepath = os.path.dirname(os.path.abspath(csv_path))
+    raw_download_dir = tempfile.mkdtemp()
+    for row in rows:
+        if url: #boolean if we are using urls to get file or not
+            print(row['fulltext_url'])
+            file_full_path  = get_file.download_file(row['fulltext_url'],dwnld_dir = raw_download_dir)
+            row['files'] = file_full_path
+            row['first_file'] = file_full_path
+        metadata = create_repository_metadata(row, singular_field_names, repeating_field_names)
+        metadata_temp_path = tempfile.mkdtemp()
+        metadata_filepath = os.path.join(metadata_temp_path, 'metadata.json')
+        try:
+            with open(metadata_filepath, 'w') as repo_metadata_file:
+                json.dump(metadata, repo_metadata_file, indent=4)
+                log.debug('Writing to {}: {}'.format(metadata_filepath, json.dumps(metadata)))
+            try:
+                first_file, other_files = find_files(row['files'], row.get('first_file'), base_filepath)
+                # TODO: Handle passing existing repo id
+                repo_id = repo_import(metadata_filepath, metadata['title'], first_file, other_files, None,
+                                      ingest_command,
+                                      ingest_path,
+                                      ingest_depositor)
+                # TODO: Write repo id to output CSV
+            except Exception as e:
+                # TODO: Record exception to output CSV
+                raise e
+        finally:
+            if (not config.debug_mode) and os.path.exists(metadata_filepath):
+                shutil.rmtree(metadata_temp_path, ignore_errors=True)
+                if os.path.exists(raw_download_dir):
+                    shutil.rmtree(raw_download_dir, ignore_errors=True)
 
 def load_csv(filepath):
     """
@@ -29,26 +71,51 @@ def load_csv(filepath):
         return reader.fieldnames, list(reader)
 
 
-def validate_field_names(field_names):
+def validate_field_names(field_names,use_url):
+    """
+    ensures the required fields are present in the data source
+    """
     log.debug('Validating field names')
     for field_name in required_field_names:
+        if field_name == 'files':
+            if use_url:
+                continue #we dont need this if we use urls instead
+        if field_name == 'fulltext_url':
+            if not use_url:
+                continue #we dont need this if we have paths instead of urls
         assert field_name in field_names
 
 
 def analyze_field_names(field_names):
+    """
+    Desc: a function that decides what fields are has_many and what are single_value
+        aka what will be a list of values versus single value
+    Args:
+        field_names (list): all the field names from the original metadata information provided
+    Returns: touple of where first value is the names of items which will be single values.
+        second item of touple is the names of fields which will be lists and are \
+        currently labeled like creator1 creator2 creator3
+
+    """
     repeating_field_names = set()
     singular_field_names = set()
     for field_name in sorted(field_names):
-        match = re.fullmatch('(.+)(\d+)', field_name)
+        match = re.fullmatch('(.+)(\d+$)', field_name)
         if not match:
             singular_field_names.add(field_name)
         else:
             name_part, number_part = match.groups()
+            while re.match('\d',name_part[-1]):
+                number_part = name_part[-1] + number_part
+                name_part = name_part[:-1]
             if number_part == '1':
                 repeating_field_names.add(name_part)
             elif name_part not in repeating_field_names:
                 singular_field_names.add(field_name)
-    singular_field_names.remove('files')
+    if 'files' in singular_field_names:
+        singular_field_names.remove('files')
+    if 'fulltext_url' in singular_field_names:
+        singular_field_names.remove('fulltext_url')
     if 'first_file' in singular_field_names:
         singular_field_names.remove('first_file')
     log.debug('Singular field names: {}'.format(singular_field_names))
@@ -57,6 +124,18 @@ def analyze_field_names(field_names):
 
 
 def create_repository_metadata(row, singular_field_names, repeating_field_names):
+    """
+    DESC: given a line from the csv this function returns a dictionary of metadata
+         with lists instead of repeated fileds followed by a number
+         ie { "title": "joe","creator1": "larry", "creator2" : "james" }
+         becomes { "title": "joe","creator": ["larry", "james"] }
+    Args:
+        row (dict): a line from the csv with fieldname:value (as a dict)
+        singular_field_names (set): a list of fields that are not to be listsself.
+            calculated in analyze_field_names()
+        repeating_field_names (set): a list of field names which will be lists (has many) not single value
+    Return: dict representing metadata
+    """
     metadata = dict()
     for field_name in singular_field_names:
         metadata[field_name] = row[field_name] if row[field_name] != '' else None
@@ -76,6 +155,13 @@ def create_repository_metadata(row, singular_field_names, repeating_field_names)
 
 
 def find_files(row_filepath, row_first_filepath, base_filepath):
+    """
+    Desc: this function will locate all the files and check to ensure the primary file is present
+    Args: row_filepath (str) the path to the file or directory that contains relevent resourcesself.
+    Return: touple
+        first element (str): path to the primary file
+        second element (set): list of other files relating to the work (does not include primary file)
+    """
     filepath = os.path.join(base_filepath, row_filepath)
     if not os.path.exists(filepath):
         raise FileNotFoundError(filepath)
@@ -106,6 +192,24 @@ def find_files(row_filepath, row_first_filepath, base_filepath):
 
 def repo_import(repo_metadata_filepath, title, first_file, other_files, repository_id, ingest_command,
                 ingest_path, ingest_depositor):
+    """
+    Desc: this function takes in relevant information and paths and calls the rake
+        task to ingest the work into Hyrax
+    Args:
+        repo_metadata_filepath (str): path to the file which contains nested json
+            representing the metadata (basically the python dict in a file)
+        title (str): the title of the work to be uploaded
+        first_file (str): the path to the primary file
+        other_files (set): list of the rest of the file paths
+        repository_id (str or None): [Optional] id of the original work to which
+            this is an update if None this is a new work to add
+        ingest_command (str): the command to execute the rake task - set in the
+            config.py file
+        ingest_path (str): the directory of our rails project - set in config.py
+        ingest_depositor (str): the username of the person depositing the
+            information - set in the config.py file
+    Returns: the id of the work in hyrax
+    """
     log.info('Importing %s.', title)
     # rake gwss:ingest_etd -- --manifest='path-to-manifest-json-file' --primaryfile='path-to-primary-attachment-file/myfile.pdf' --otherfiles='path-to-all-other-attachments-folder'
     command = ingest_command.split(' ') + ['--',
@@ -130,40 +234,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Loads into GW Scholarspace from CSV')
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('csv', help='filepath of CSV file')
-
+    parser.add_argument('--url', action='store_true')
     args = parser.parse_args()
-
-    logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO
-    )
-    logging.basicConfig(level=logging.DEBUG)
-
-    field_names, rows = load_csv(args.csv)
-    log.info('Loading {} object from {}'.format(len(rows), args.csv))
-    validate_field_names(field_names)
-    singular_field_names, repeating_field_names = analyze_field_names(field_names)
-
-    base_filepath = os.path.dirname(os.path.abspath(args.csv))
-
-    for row in rows:
-        metadata = create_repository_metadata(row, singular_field_names, repeating_field_names)
-        metadata_temp_path = tempfile.mkdtemp()
-        metadata_filepath = os.path.join(metadata_temp_path, 'metadata.json')
-        try:
-            with open(metadata_filepath, 'w') as repo_metadata_file:
-                json.dump(metadata, repo_metadata_file, indent=4)
-                log.debug('Writing to {}: {}'.format(metadata_filepath, json.dumps(metadata)))
-            try:
-                first_file, other_files = find_files(row['files'], row.get('first_file'), base_filepath)
-                # TODO: Handle passing existing repo id
-                repo_id = repo_import(metadata_filepath, metadata['title'], first_file, other_files, None,
-                                      config.ingest_command,
-                                      config.ingest_path,
-                                      config.ingest_depositor)
-                # TODO: Write repo id to output CSV
-            except Exception as e:
-                # TODO: Record exception to output CSV
-                raise e
-        finally:
-            if (not config.debug_mode) and os.path.exists(metadata_filepath):
-                shutil.rmtree(metadata_temp_path, ignore_errors=True)
+    run_ingest_process(args.csv,config.ingest_command, config.ingest_path, config.ingest_depositor,url = args.url,debug = args.debug)

--- a/example/url_example.csv
+++ b/example/url_example.csv
@@ -1,0 +1,3 @@
+"resource_type1","title1","creator1","creator2","resource_type2","license1","fulltext_url"
+"filefromurl","gps file form url","Littman, Justin","Trent, Rachel","journal",,"http://eprojects.wpi.edu/sites/default/files/gps-posters/2017/12/07/Samantha%20Morton%20GPS%20REAL%20final%20poster.pdf"
+"cowtang","URL from epj xls","Littman, Justin",,journal,"http://creativecommons.org/licenses/by/3.0/us/","https://web.wpi.edu/Pubs/E-project/Available/E-project-050507-133820/unrestricted/RafaelMartinezNadalRTchart.xls"

--- a/get_file.py
+++ b/get_file.py
@@ -1,0 +1,95 @@
+import re
+import os
+import time
+import subprocess
+from lxml import etree
+import xml.etree.ElementTree as xtree
+import requests
+import validators
+import getpass
+from urllib.parse import unquote
+#written for WPI ingesting from URL
+class UrlException(ValueError):
+	pass
+def get_file_name_from_url(url):
+	print(url)
+	match = re.search("[/][^/]+[/]$",url)
+	if match:#Directory with / at the end
+		start = match.start() +1
+		end = match.end() -1
+		fileName = url[start:end]
+		fileName = unquote(fileName)
+		return fileName
+	match = re.search("[/][^/]+$",url)
+	if match:
+		start = match.start() +1
+		end = match.end()
+		fileName = url[start:end]
+		fileName = unquote(fileName)
+		return fileName
+	raise ValueError('unable to figure anything out whatso ever {} '.format(url))
+
+def grant_access(path,rights = '775'):
+	this_user = getpass.getuser()
+	subprocess.run(['sudo','chmod',rights,path], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+	return subprocess.run(['sudo','chown',this_user,path], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+
+
+def download_file(url,dwnld_dir = None):
+	""" if the given url is valid and we have access to the file attached to it. this funciton
+	will download said file to the directory given or just put it in the current dir."""
+	local_filename = get_file_name_from_url(url)
+	if dwnld_dir is not None:
+		if dwnld_dir[-1] == '/':
+			local_filename = dwnld_dir+local_filename
+		else:
+			local_filename = dwnld_dir+'/'+local_filename
+	if not os.path.exists(dwnld_dir):
+		mkdir(dwnld_dir,['-p'])#make directory and make all directories that dont exist on the way
+	# NOTE the stream=True parameter
+	while True:
+		try:
+			if not validators.url(url.replace('[','B').replace(']','Be')):
+				raise UrlException('Invalid url: {}'.format(url))
+
+			r = requests.get(url, stream =True)
+			break
+		except requests.exceptions.ConnectionError as e:
+			print('i never give up\n',e,'\n',url)
+			time.sleep(2)
+
+	if 200 <= r.status_code <= 299:
+		try:
+			with open(local_filename, 'wb') as f:
+				for chunk in r.iter_content(chunk_size=1024):
+					if chunk: # filter out keep-alive new chunks
+						f.write(chunk)
+						#f.flush() commented by recommendation from J.F.Sebastian
+			return os.path.abspath(local_filename)
+		except PermissionError as e:
+			if dwnld_dir:
+				print('granting access to file')
+
+				if grant_access(dwnld_dir).returncode == 0:
+					print('success')
+					return download_file(url,dwnld_dir)
+
+			raise
+	print('failed to download file error:{}, {}'.format(r.status_code,url))
+	text = ''
+	if r.text is not None:
+		if len(r.text)>= 100:
+			text = r.text[:100]+'...'
+		else:
+			text = r.text
+	raise UrlException('failed to download file.@{} code:{},body:{}'.format(url,r.status_code,text))
+
+def mkdir(path,args = None):
+	if args is None:
+		args = []
+	status = subprocess.run(['mkdir']+args+[path], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+	if status.returncode == 0:
+		return
+	this_user = getpass.getuser()
+	subprocess.run(['sudo','mkdir','-m','775']+args+[path], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+	return subprocess.run(['sudo','chown',this_user,path], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)


### PR DESCRIPTION
support having url of resource for a given  work instead of path to a file, currently ONLY if all works in csv have this, and fulltext-url col name is present instead of files. wrote relevant python code for downloading the files & documented original code